### PR TITLE
Ignore bad Postgres connection

### DIFF
--- a/delayed_job.gemspec
+++ b/delayed_job.gemspec
@@ -2,6 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.add_dependency 'activesupport', ['>= 3.0', '< 6.2']
+  spec.add_dependency 'pg'
   spec.authors        = ['Brandon Keepers', 'Brian Ryckbost', 'Chris Gaffney', 'David Genord II', 'Erik Michaels-Ober', 'Matt Griffin', 'Steve Richert', 'Tobias Lütke']
   spec.description    = 'Delayed_job (or DJ) encapsulates the common pattern of asynchronously executing longer tasks in the background. It is a direct extraction from Shopify where the job table is responsible for a multitude of core tasks.'
   spec.email          = ['brian@collectiveidea.com']

--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -316,6 +316,10 @@ module Delayed
       job = Delayed::Job.reserve(self)
       @failed_reserve_count = 0
       job
+    rescue ::PG::ConnectionBad => error
+      # ignore DB restarts and keep trying
+      Delayed::Job.recover_from(error)
+      nil
     rescue ::Exception => error # rubocop:disable RescueException
       say "Error while reserving job: #{error}"
       Delayed::Job.recover_from(error)

--- a/lib/delayed_job.rb
+++ b/lib/delayed_job.rb
@@ -1,4 +1,5 @@
 require 'active_support'
+require 'pg'
 require 'delayed/compatibility'
 require 'delayed/exceptions'
 require 'delayed/message_sending'


### PR DESCRIPTION
When the database restarts, the worker loses the connection. If it fails to connect 10 times, the worker exits.

This PR changes that so it will ignore the failures and keep trying to connect.